### PR TITLE
Change Fingerprint process to finish after loading all providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ebanx-lib-js",
+  "name": "@ebanx/lib-js",
   "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
This PR makes the fingerprint process callback to be called when all the
providers have finished loading and calling the save session_id.